### PR TITLE
Fix Nuitka CI: pin action/version, use explicit mode, and stage artifacts

### DIFF
--- a/.github/workflows/nuitka-build.yml
+++ b/.github/workflows/nuitka-build.yml
@@ -1,6 +1,5 @@
 name: CI
 
-# Controls when the workflow will run
 on:
   release:
     types: [created]
@@ -11,61 +10,54 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      # Check-out repository
       - name: Check-out repository
         uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
           architecture: 'x64'
 
       - name: Install Dependencies
         run: |
           pip install -r requirements.txt
 
-      # Build CLI executable
       - name: Build CLI EXE
-        uses: Nuitka/Nuitka-Action@main
+        uses: Nuitka/Nuitka-Action@v1.4
         with:
-          nuitka-version: main
+          nuitka-version: 4.0.1
           script-name: src/save_editor.py
-          onefile: true
+          mode: onefile
           windows-icon-from-ico: assets/save.png
           windows-product-name: Disco Elysium Save Editor
           windows-product-version: "1.1.0"
           windows-file-description: A Save Editor for Disco Elysium
+          output-dir: build/cli
           output-file: DESE
 
-      # Move CLI build out of the way before GUI build
-      - name: Stash CLI build
-        shell: bash
-        run: |
-          cp build/DESE.exe DESE.exe
-
-      # Build GUI executable
       - name: Build GUI EXE
-        uses: Nuitka/Nuitka-Action@main
+        uses: Nuitka/Nuitka-Action@v1.4
         with:
-          nuitka-version: main
+          nuitka-version: 4.0.1
           script-name: src/gui_editor.py
-          onefile: true
+          mode: onefile
           enable-plugins: pyqt6
           windows-disable-console: true
           windows-icon-from-ico: assets/save.png
           windows-product-name: Disco Elysium Save Editor
           windows-product-version: "1.1.0"
           windows-file-description: Save editor for Disco Elysium with PyQt6 GUI
+          output-dir: build/gui
           output-file: DiscoElysiumSaveEditor
 
-      # Restore CLI build alongside GUI build
-      - name: Restore CLI build
+      - name: Stage release artifacts
         shell: bash
         run: |
-          cp DESE.exe build/DESE.exe
+          mkdir -p build
+          cp build/cli/DESE.exe build/DESE.exe
+          cp build/gui/DiscoElysiumSaveEditor.exe build/DiscoElysiumSaveEditor.exe
 
-      # Upload artifacts
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
### Motivation
- Prevent CI breakage from upstream changes by pinning the Nuitka GitHub Action and the Nuitka version. 
- Align workflow inputs with the action's current schema by replacing legacy `onefile: true` with explicit `mode: onefile` to avoid unexpected behavior. 
- Prevent the CLI and GUI builds from clobbering each other's outputs by writing separate output directories and adding a staging step for release artifacts.

### Description
- Pin `Nuitka/Nuitka-Action` to `@v1.4` and set `nuitka-version: 4.0.1` instead of tracking `main`. 
- Use `mode: onefile` for both CLI and GUI builds and pin the runner Python to `3.11`. 
- Emit CLI and GUI builds to `build/cli` and `build/gui` respectively, and add a `Stage release artifacts` step that copies the two EXEs into `build/` for upload. 
- Simplify artifact handling by removing the temporary stash/restore steps and using explicit `output-dir`/`output-file` settings.

### Testing
- Queried the Nuitka-Action repository tags and the Nuitka PyPI version with `git ls-remote` and a short Python HTTP request to determine stable versions (succeeded). 
- Reviewed the updated workflow file contents with `git diff` and `nl -ba .github/workflows/nuitka-build.yml` to verify the changes (succeeded). 
- Attempted to parse the workflow YAML with `python -c "import yaml; yaml.safe_load(open('.github/workflows/nuitka-build.yml'))"`, which failed due to `PyYAML` not being installed in this environment (manual install required to run this parse). 
- Confirmed repository state with `git status --short` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999587afca88329bb040b094dbf10ba)